### PR TITLE
add first param for methods in configure and initializer templates

### DIFF
--- a/swifty_viper/Code/Configurator/configurator.swift.liquid
+++ b/swifty_viper/Code/Configurator/configurator.swift.liquid
@@ -13,7 +13,7 @@ class {{ module_info.name }}ModuleConfigurator {
     func configureModuleForViewInput<UIViewController>(viewInput: UIViewController) {
 
         if let viewController = viewInput as? {{ module_info.name }}ViewController {
-            configure(viewController)
+            configure(viewController: viewController)
         }
     }
 

--- a/swifty_viper/Code/Configurator/initializer.swift.liquid
+++ b/swifty_viper/Code/Configurator/initializer.swift.liquid
@@ -16,7 +16,7 @@ class {{ module_info.name }}ModuleInitializer: NSObject {
     override func awakeFromNib() {
 
         let configurator = {{ module_info.name }}ModuleConfigurator()
-        configurator.configureModuleForViewInput({{ module_info.name | downcase }}ViewController)
+        configurator.configureModuleForViewInput(viewInput: {{ module_info.name | downcase }}ViewController)
     }
 
 }

--- a/swifty_viper/Tests/Configurator/configurator_tests.swift.liquid
+++ b/swifty_viper/Tests/Configurator/configurator_tests.swift.liquid
@@ -27,7 +27,7 @@ class {{ module_info.name }}ModuleConfiguratorTests: XCTestCase {
         let configurator = {{ module_info.name }}ModuleConfigurator()
 
         //when
-        configurator.configureModuleForViewInput(viewController)
+        configurator.configureModuleForViewInput(viewInput: viewController)
 
         //then
         XCTAssertNotNil(viewController.output, "{{ module_info.name }}ViewController is nil after configuration")


### PR DESCRIPTION
after adding module of swifty_viper template, xcode corrects these methods